### PR TITLE
Update main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,6 @@ fn encrypt_file_streaming(
         .open(out_path)?;
     let mut wtr = BufWriter::new(outfile);
 
-    // Create the StreamSealer and get the nonce
     let (mut sealer, nonce) = StreamSealer::new(secret_key)
         .map_err(|_| io::Error::other("Failed to create StreamSealer"))?;
 


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove redundant comment from streaming encryption function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["encrypt_file_streaming function"] -- "remove comment" --> B["Cleaner code without redundant documentation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Remove redundant comment from encryption function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<ul><li>Removed redundant comment "Create the StreamSealer and get the nonce" <br>that duplicated the code's intent<br> <li> Comment was unnecessary as the code is self-documenting</ul>


</details>


  </td>
  <td><a href="https://github.com/Voornaamenachternaam/Filecryption/pull/245/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Voornaamenachternaam/Filecryption/245)
<!-- Reviewable:end -->
